### PR TITLE
CAP-96 create initial unit test framework

### DIFF
--- a/sniffer.py
+++ b/sniffer.py
@@ -183,7 +183,6 @@ class PacketSniffer:
                     ips.append(ip.get_info())
         finally:
             self.lock.release() # release lock
-        print(progs)
         return {
         "links": links,
         "ip_nodes": ips,

--- a/sniffer.py
+++ b/sniffer.py
@@ -111,8 +111,7 @@ class PacketSniffer:
                     self.icmp_procs[id].update_timestamp()
                 else:
                     self.icmp_procs[id] = ProgInfo(proc.name(), NO_PORT, proc.pid)
-            print(proc.pid)
-        # deal with if not found process
+        # find which process to return
         toReturn = ProgInfo(NO_PROC, NO_PORT, NO_PROC)
         if id in self.icmp_procs:
             toReturn = self.icmp_procs[id]

--- a/sniffer.py
+++ b/sniffer.py
@@ -107,13 +107,15 @@ class PacketSniffer:
         # find process by id
         for proc in process_iter():
             if(proc.pid == id):
-                self.icmp_procs[id] = ProgInfo(proc.name(), NO_PORT, proc.pid)
+                if id in self.icmp_procs:
+                    self.icmp_procs[id].update_timestamp()
+                else:
+                    self.icmp_procs[id] = ProgInfo(proc.name(), NO_PORT, proc.pid)
             print(proc.pid)
         # deal with if not found process
         toReturn = ProgInfo(NO_PROC, NO_PORT, NO_PROC)
         if id in self.icmp_procs:
             toReturn = self.icmp_procs[id]
-            self.icmp_procs[id].update_timestamp()
         return toReturn
 
 

--- a/unit-tests/sniffer-test.py
+++ b/unit-tests/sniffer-test.py
@@ -474,8 +474,78 @@ class SnifferTest(unittest.TestCase):
         # Assert
         self.assertEqual(result, wantedResult)
 
+    def test_get_link_packets__no_link_exists__return_empty_list(self):
+        # Arrange
+        ip = "122.212.23.34"
+        name = "ping"
+        port = 8080
+        fd = 400
+        wantedResult = []
 
+        # Act
+        result = self.sniffer.get_link_packets(ip, name, port, fd)
 
+        # Assert
+        self.assertEqual(result, wantedResult)
+
+    def test_get_link_packets__link_exists__return_list_with_packets_over_link(self):
+        # Arrange
+        ip = "122.212.23.34"
+        name = "ping"
+        port = 8080
+        fd = 400
+
+        prog = self.fake_new_prog_info(name, port, fd)
+        wrongProg = self.fake_new_prog_info("jeremy", 20, 23)
+        prog_nodes = {
+            prog: Mock(),
+            wrongProg: Mock()
+        }
+
+        packetsrc = Mock()
+        packetsrc.src = ip
+        packetsrc.dest = "123.123.123.123"
+        packetsrc.get_info.return_value = packetsrc
+
+        packet0 = Mock()
+        packet0.src = "123.456.789.123"
+        packet0.dest = "123.123.123.123"
+        packet0.get_info.return_value = packet0
+
+        packetdest = Mock()
+        packetdest.src = "123.123.123.123"
+        packetdest.dest = ip
+        packetdest.get_info.return_value = packetdest
+
+        packet1 = Mock()
+        packet1.src = "123.456.789.123"
+        packet1.dest = "123.123.123.123"
+        packet1.get_info.return_value = packet1
+
+        packet2 = Mock()
+        packet2.src = "123.456.789.123"
+        packet2.dest = "123.123.123.123"
+        packet2.get_info.return_value = packet2
+
+        packet3 = Mock()
+        packet3.src = "123.456.789.123"
+        packet3.dest = "123.123.123.123"
+        packet3.get_info.return_value = packet3
+
+        packets = [packetsrc, packet0, packetdest]
+        wrongPackets = [packet1, packet2, packet3]
+
+        prog_nodes[prog].packets = packets
+        prog_nodes[wrongProg].packets = wrongPackets
+        self.sniffer.prog_nodes = prog_nodes
+
+        wantedResult = [packetsrc, packetdest]
+
+        # Act
+        result = self.sniffer.get_link_packets(ip, name, port, fd)
+
+        # Assert
+        self.assertEqual(result, wantedResult)
 
     # Helper Methods -----------------------------------------------------------
     def get_net_connections_value(self, cons):

--- a/unit-tests/sniffer-test.py
+++ b/unit-tests/sniffer-test.py
@@ -1,0 +1,147 @@
+import unittest
+from unittest.mock import Mock, patch
+
+# mock imports
+import sys
+sys.modules['psutil'] = Mock()
+import psutil as psutilMock
+
+sys.modules['data_structures.node'] = Mock()
+# import data_structures.node
+from data_structures.node import ProgNode as progNodeMock
+from data_structures.node import ProgInfo as progInfoMock
+
+# imports to test
+import sniffer as sniffModule
+from constants import *
+
+class SnifferTest(unittest.TestCase):
+    sniffer = sniffModule.PacketSniffer()
+    net_connections_mock = Mock()
+
+    def tearDown(self):
+        psutilMock.reset_mock()
+        progNodeMock.reset_mock()
+        progInfoMock.reset_mock()
+
+        self.sniffer.port_procs = {}
+
+    def test_get_ip_hostname__seen_address__return_address(self):
+        # Arrange
+        ip = '172.19.168.43'
+        address = 'google.com'
+        self.sniffer.seen_ips[ip] = address
+
+        # Act
+        result = self.sniffer.get_ip_hostname(ip)
+
+        # Assert
+        self.assertEqual(result, address)
+
+    def test_get_ip_hostname__new_address__return_no_hostname(self):
+        # Arrange
+        ip = '172.19.168.44'
+
+        # Act
+        result = self.sniffer.get_ip_hostname(ip)
+
+        # Assert
+        self.assertEqual(result, NO_HOSTNAME)
+
+    def test_save_dns_reply_value__new_address__save_address(self):
+        # Arrange
+        self.sniffer.seen_ips = {}
+        ip = '172.19.168.43'
+        address = 'google.com'
+
+        # Act
+        self.sniffer.save_dns_reply_value(ip, address)
+
+        # Assert
+        self.assertIn(ip, self.sniffer.seen_ips)
+
+    def test_check_if_src_or_dest__localhost_src__return__src(self):
+        # Arrange
+        src = self.sniffer.my_ip
+        dest = '333.333.33.33'
+
+        # Act
+        result = self.sniffer.check_if_src_or_dest(src, dest)
+
+        # Assert
+        self.assertEqual(result, SRC)
+
+    def test_check_if_src_or_dest__localhost_dest__return__dest(self):
+        # Arrange
+        src = '333.333.33.33'
+        dest = self.sniffer.my_ip
+
+        # Act
+        result = self.sniffer.check_if_src_or_dest(src, dest)
+
+        # Assert
+        self.assertEqual(result, DEST)
+
+    def test_associate_port_with_process__port_in_use_and_port_new__add_port_to_process_node(self):
+        # Arrange
+        port = 25
+        pid = 1234
+        psutilMock.net_connections.return_value = self.get_net_connections_value([(pid, port)])
+        nameReturned = "testname"
+        psutilMock.Process().name.return_value = nameReturned
+        processReturned = "testProcess"
+        progInfoMock.return_value = processReturned
+
+        # Act
+        result = self.sniffer.associate_port_with_process(port)
+
+        # Assert
+        # psutilMock.Process().name.assert_called_once()
+        progInfoMock.assert_called_with(nameReturned, port, pid)
+        self.assertEqual(result, processReturned)
+
+    def test_associate_port_with_process__port_in_use_and_port_exists__update_process_node(self):
+        # Arrange
+        port = 25
+        psutilMock.net_connections.return_value = self.get_net_connections_value([(0,port)])
+        processMock = Mock()
+        self.sniffer.port_procs[port] = processMock
+
+        # Act
+        result = self.sniffer.associate_port_with_process(port)
+
+        # Assert
+        processMock.update_timestamp.assert_called_once()
+        self.assertEqual(result, processMock)
+
+    def test_associate_port_with_process__port_not_in_use_and_port_existed__return_old_node(self):
+        # Arrange
+        port = 25
+        psutilMock.net_connections.return_value = []
+        processMock = Mock()
+        self.sniffer.port_procs[port] = processMock
+
+        # Act
+        result = self.sniffer.associate_port_with_process(port)
+
+        # Assert
+        self.assertEqual(result, processMock)
+
+    def test_associate_port_id_with_process__proc_exists_not_seen__return_new_proc(self):
+        pass
+
+
+
+
+    # Helper Methods -----------------------------------------------------------
+    def get_net_connections_value(self, cons):
+        connections = []
+        for con in cons:
+            connection = Mock()
+            connection.pid = con[0]
+            connection.laddr.port = con[1]
+            connections.append(connection)
+        return connections
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Framework created for backend and many unit tests written. Still missing unit tests for some functions. Merging to allows simultaneous work on overarching testing scheme